### PR TITLE
Added another condition to satisfy the roll up of nested tasks

### DIFF
--- a/src/components/ActionPlanTable.js
+++ b/src/components/ActionPlanTable.js
@@ -20,7 +20,12 @@ class ActionPlanTable extends React.Component {
 		} else if (tasks[key]['dependentChildren']) {
 			tasks[key]['expanded'] = value
 			Object.keys(tasks).forEach((task_id) => {
-				if ( task_id !== key && tasks[task_id]['expanded'] !== value && tasks[task_id]['dependentChildren'] && parseInt(task_id, 10) !== tasks[key]['dependentParent'] ) {
+				if ((task_id !== key)
+					&& (tasks[task_id]['expanded'] !== value)
+					&& (tasks[task_id]['dependentChildren'])
+					&& (tasks[task_id]['dependentParent'] == key)
+					&& (parseInt(task_id, 10) != tasks[key]['dependentParent']))
+				{
 					this.recursiveToggle(task_id, value, tasks)
 				}
 			})


### PR DESCRIPTION
This is fix the rollup, but it won't fix the issue with the chevron not pointing the right way when you open up the task tree. 